### PR TITLE
fix: summary tab in asset view modal

### DIFF
--- a/app/(protected)/dashboard/[asset]/newPage.tsx
+++ b/app/(protected)/dashboard/[asset]/newPage.tsx
@@ -4,6 +4,7 @@ import {
   TConversionRates,
   THistoricalData,
   TInterval,
+  TLineChartData,
   TPreference,
   TProfitLoss,
   TUnrealisedProfitLoss,
@@ -34,6 +35,7 @@ function Page({
   unrealisedResults,
   realisedResults,
   lineChartData,
+  assetsChartData,
   preferences,
   assetTableData,
 }: {
@@ -47,12 +49,10 @@ function Page({
   preferences: TPreference;
   unrealisedResults: TUnrealisedProfitLoss[];
   realisedResults: TProfitLoss[];
-  lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
+  lineChartData: TLineChartData;
+  assetsChartData: {
+    assetId: string;
+    lineChartData: TLineChartData;
   }[];
   assetTableData: {
     interval: string;
@@ -170,6 +170,7 @@ function Page({
                     unrealisedResults={unrealisedResults}
                     realisedResults={realisedResults}
                     lineChartData={lineChartData}
+                    assetsChartData={assetsChartData}
                     preferences={preferences}
                   />
                 ) : (

--- a/app/(protected)/dashboard/[asset]/newPage.tsx
+++ b/app/(protected)/dashboard/[asset]/newPage.tsx
@@ -169,7 +169,6 @@ function Page({
                     conversionRates={conversionRates}
                     unrealisedResults={unrealisedResults}
                     realisedResults={realisedResults}
-                    lineChartData={lineChartData}
                     assetsChartData={assetsChartData}
                     preferences={preferences}
                   />

--- a/app/(protected)/dashboard/[asset]/page.tsx
+++ b/app/(protected)/dashboard/[asset]/page.tsx
@@ -10,7 +10,7 @@ import { getHistoricalData } from "@/services/thirdParty/twelveData";
 import { getConversionRate } from "@/services/thirdParty/currency";
 import { getPreferenceFromUserId } from "@/services/preference";
 import { getUnrealisedProfitLossArray } from "@/helper/unrealisedValueCalculator";
-import { TAsset, TUnrealisedProfitLoss } from "@/types/types";
+import { TAsset, TLineChartData, TUnrealisedProfitLoss } from "@/types/types";
 import { getAssetTableData } from "@/services/dashboard/assets/assetTableData";
 import { calculateRealisedProfitLoss } from "@/helper/realisedValueCalculator";
 import { getLineChartData } from "@/helper/prepareLineChartData";
@@ -57,12 +57,14 @@ export default async function AssetPage({
   }
 
   let unrealisedResults: TUnrealisedProfitLoss[] = [];
-  let lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
+  let assetsUnrealisedResults: {
+    assetId: string;
+    unrealisedResults: TUnrealisedProfitLoss[];
+  }[] = [];
+  let lineChartData: TLineChartData = [];
+  let assetsChartData: {
+    assetId: string;
+    lineChartData: TLineChartData;
   }[] = [];
   let assetTableData: {
     interval: string;
@@ -76,6 +78,13 @@ export default async function AssetPage({
       currencyConversionRates
     );
     lineChartData = await getLineChartData(historicalData);
+
+    historicalData.forEach(async (data) => {
+      assetsChartData.push({
+        assetId: data.assetId,
+        lineChartData: await getLineChartData([data]),
+      });
+    });
     assetTableData = await getAssetTableData(filteredAssets, unrealisedResults);
   }
 
@@ -94,6 +103,7 @@ export default async function AssetPage({
       filteredAssets={filteredAssets}
       historicalData={historicalData}
       lineChartData={lineChartData}
+      assetsChartData={assetsChartData}
       conversionRates={currencyConversionRates}
       preferences={preferences}
       unrealisedResults={unrealisedResults}

--- a/app/(public)/[username]/page.tsx
+++ b/app/(public)/[username]/page.tsx
@@ -16,6 +16,7 @@ import LoadingSpinner from "@/components/ui/loading-spinner";
 import PortfolioLineChart from "@/components/portfolioLineChart";
 import PerformanceMetrics from "@/components/performanceMetrics";
 import { getLineChartData } from "@/helper/prepareLineChartData";
+import { TLineChartData } from "@/types/types";
 
 export default async function PublicProfile({
   params,
@@ -41,15 +42,19 @@ export default async function PublicProfile({
   );
   const historicalData = await getHistoricalData(user.id, assets);
 
-  let lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
+  let lineChartData: TLineChartData = [];
+  let assetsChartData: {
+    assetId: string;
+    lineChartData: TLineChartData;
   }[] = [];
   if (historicalData.length) {
     lineChartData = await getLineChartData(historicalData);
+    historicalData.forEach(async (data) => {
+      assetsChartData.push({
+        assetId: data.assetId,
+        lineChartData: await getLineChartData([data]),
+      });
+    });
   }
 
   const unrealisedResults = getUnrealisedProfitLossArray(
@@ -145,7 +150,7 @@ export default async function PublicProfile({
                     <AssetTable
                       isPublic
                       data={assets}
-                      lineChartData={lineChartData}
+                      assetsChartData={assetsChartData}
                       unrealisedResults={unrealisedResults}
                       realisedResults={realisedResults}
                       conversionRates={conversionRates}

--- a/components/assetTable.tsx
+++ b/components/assetTable.tsx
@@ -3,6 +3,7 @@ import {
   TAsset,
   TConversionRates,
   THistoricalData,
+  TLineChartData,
   TPreference,
   TProfitLoss,
   TUnrealisedProfitLoss,
@@ -20,12 +21,10 @@ interface AssetTableProps {
   isPublic?: boolean;
   unrealisedResults?: TUnrealisedProfitLoss[];
   realisedResults?: TProfitLoss[];
-  lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
+  lineChartData: TLineChartData;
+  assetsChartData: {
+    assetId: string;
+    lineChartData: TLineChartData;
   }[];
   conversionRates: TConversionRates;
   preferences: TPreference;
@@ -37,6 +36,7 @@ function AssetTable({
   unrealisedResults,
   realisedResults,
   lineChartData,
+  assetsChartData,
   conversionRates,
   preferences,
 }: AssetTableProps) {
@@ -81,8 +81,18 @@ function AssetTable({
               setOpen={setOpen}
               assetToView={assetToView}
               manualAsset={manualAsset}
-              chartData={lineChartData}
-              unrealisedResults={unrealisedResults}
+              chartData={
+                assetsChartData.filter(
+                  (assetChartData) =>
+                    assetChartData.assetId ===
+                    (assetToView?.id || manualAsset?.id)
+                )[0]?.lineChartData
+              }
+              unrealisedResults={unrealisedResults.filter(
+                (assetUnrealisedResult) =>
+                  assetUnrealisedResult.assetId ===
+                  (assetToView?.id || manualAsset?.id)
+              )}
               realisedResults={realisedResults}
               conversionRates={conversionRates}
               numberSystem={preferences.numberSystem}

--- a/components/assetTable.tsx
+++ b/components/assetTable.tsx
@@ -21,7 +21,6 @@ interface AssetTableProps {
   isPublic?: boolean;
   unrealisedResults?: TUnrealisedProfitLoss[];
   realisedResults?: TProfitLoss[];
-  lineChartData: TLineChartData;
   assetsChartData: {
     assetId: string;
     lineChartData: TLineChartData;
@@ -35,7 +34,6 @@ function AssetTable({
   historicalData,
   unrealisedResults,
   realisedResults,
-  lineChartData,
   assetsChartData,
   conversionRates,
   preferences,

--- a/components/viewAsset.tsx
+++ b/components/viewAsset.tsx
@@ -2,12 +2,9 @@ import React, { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { Dialog, DialogContent } from "./ui/dialog";
 import { cn } from "@/lib/helper";
-import { accumulateLineChartData } from "@/helper/lineChartDataAccumulator";
 import ChangeInterval from "./changeInterval";
 import AssetLineChart from "./assetLineChart";
-import { prepareLineChartData } from "@/helper/prepareLineChartData";
 import TransactionHistory from "./transactionHistory";
-import { prepareHistoricalDataForManualCategory } from "@/helper/manualAssetsHistoryMaker";
 import {
   TAsset,
   TInterval,

--- a/helper/manualAssetsHistoryMaker.ts
+++ b/helper/manualAssetsHistoryMaker.ts
@@ -166,6 +166,7 @@ export function prepareHistoricalDataForManualCategory(
     aggregatedAssetData.shift();
     historicalData.push({
       values: aggregatedAssetData,
+      assetId: asset.id,
       assetSymbol: asset.symbol,
       assetType: asset.category,
     });

--- a/helper/unrealisedValueCalculator.ts
+++ b/helper/unrealisedValueCalculator.ts
@@ -1,4 +1,9 @@
-import { TAsset, TConversionRates, THistoricalData } from "@/types/types";
+import {
+  TAsset,
+  TConversionRates,
+  THistoricalData,
+  TUnrealisedProfitLoss,
+} from "@/types/types";
 import { calculateTotalQuantity } from "./transactionValueCalculator";
 
 // Function to calculate unrealized profit/loss for each asset
@@ -19,16 +24,7 @@ export function getUnrealisedProfitLossArray(
   assets: TAsset[],
   conversionRates: TConversionRates
 ) {
-  const results: {
-    category: string;
-    symbol: string;
-    compareValue: string;
-    valueAtInterval: number;
-    currentValue: string;
-    prevClose: string;
-    interval: string;
-    unrealisedProfitLoss: string;
-  }[] = [];
+  const results: TUnrealisedProfitLoss[] = [];
 
   const intervals = [
     { label: "1d", days: 1 },
@@ -78,6 +74,7 @@ export function getUnrealisedProfitLossArray(
       });
 
       const result = {
+        assetId: asset.id,
         category: asset.category,
         symbol: asset.symbol,
         compareValue: (

--- a/services/thirdParty/twelveData.ts
+++ b/services/thirdParty/twelveData.ts
@@ -7,8 +7,6 @@ import { areDatesEqual } from "@/lib/helper";
 import {
   TAsset,
   THistoricalData,
-  TTwelveDataHistoricalData,
-  TTwelveDataHistoricalDataErrorResponse,
   TTwelveDataInstrumentQuote,
   TTwelveDataResult,
 } from "@/types/types";
@@ -171,6 +169,7 @@ export const getHistoricalData = async (userId: string, assets: TAsset[]) => {
             dayData.date = new Date(dayData.datetime).getTime() / 1000;
             data.assetType = asset.category;
             data.assetSymbol = asset.symbol;
+            data.assetId = asset.id;
             const assetCurrency = asset.buyCurrency.toLowerCase();
             const currencyConversion = conversionRate[assetCurrency];
             const multiplier = 1 / currencyConversion;

--- a/types/types.ts
+++ b/types/types.ts
@@ -74,38 +74,6 @@ export type TTwelveDataInstrumentQuote = {
   extended_timestamp?: number;
 };
 
-export type TTwelveDataHistoricalData = {
-  meta: {
-    symbol: string;
-    interval: string;
-    currency: string;
-    exchange_timezone: string;
-    exchange: string;
-    mic_code: string;
-    type: string;
-  };
-  values: {
-    datetime: string;
-    open: string;
-    high: string;
-    low: string;
-    close: string;
-    volume: string;
-  }[];
-  status: string;
-};
-
-export type TTwelveDataHistoricalDataErrorResponse = {
-  code: number;
-  message: string;
-  status: string;
-  meta: {
-    symbol: string;
-    interval: string;
-    exchange: string;
-  };
-};
-
 export type THistoricalData = {
   meta?: {
     symbol: string;
@@ -128,9 +96,18 @@ export type THistoricalData = {
     value: number;
   }[];
   status?: string;
+  assetId: string;
   assetType: string;
   assetSymbol: string | null;
 };
+
+export type TLineChartData = {
+  interval: string;
+  data: {
+    name: string;
+    amt: number;
+  }[];
+}[];
 
 export type TInterval = "1d" | "1w" | "1m" | "1y" | "All";
 
@@ -184,6 +161,7 @@ export type TUserManualCategory = {
 };
 
 export type TUnrealisedProfitLoss = {
+  assetId: string;
   category: string;
   symbol: string;
   compareValue: string;


### PR DESCRIPTION
This PR fixes the individual asset view modal's summary tab to correctly display the values & line-chart related to the selected asset.