### PR TITLE
fix: other category to allow search for any asset

### DIFF
--- a/components/bottomBar.tsx
+++ b/components/bottomBar.tsx
@@ -30,7 +30,7 @@ import {
 import { TUserManualCategory } from "@/types/types";
 import { updatePreferenceAction } from "@/app/(protected)/dashboard/settings/actions";
 import MutualFundsForm from "./forms/mutualFundForm";
-import ManualForm from "./forms/manualForm";
+import ManualForm from "./forms/othersForm";
 import StocksForm from "./forms/stocksForm";
 import CryptoForm from "./forms/cryptoForm";
 

--- a/components/forms/formSelector.tsx
+++ b/components/forms/formSelector.tsx
@@ -13,7 +13,7 @@ import { TUserManualCategory } from "@/types/types";
 import MutualFundsForm from "./mutualFundForm";
 import StocksForm from "./stocksForm";
 import CryptoForm from "./cryptoForm";
-import ManualForm from "./manualForm";
+import OthersForm from "./othersForm";
 
 type FormSelectorPropsType = {
   usersManualCategories: TUserManualCategory[];
@@ -43,7 +43,7 @@ function FormSelector({
           <StocksForm defaultCurrency={defaultCurrency} />
           <MutualFundsForm />
           <CryptoForm defaultCurrency={defaultCurrency} />
-          <ManualForm
+          <OthersForm
             defaultCurrency={defaultCurrency}
             usersManualCategories={usersManualCategories}
           />

--- a/components/forms/othersForm.tsx
+++ b/components/forms/othersForm.tsx
@@ -15,7 +15,7 @@ import { TTwelveDataResult, TUserManualCategory } from "@/types/types";
 import { Shapes } from "lucide-react";
 import ManualTransactionForm from "../manualTransactionForm";
 
-function ManualForm({
+function OthersForm({
   defaultCurrency,
   usersManualCategories,
 }: {
@@ -53,6 +53,34 @@ function ManualForm({
     // Set the state with the initial results from the database
     setResults(resultsFromDB);
     setLoadingAsset(false);
+
+    try {
+      const resultsFromApi = await searchAssetsFromApi({
+        query: searchQuery,
+      });
+
+      // Merge resultsFromDB with resultsFromAPI, keeping all items from resultsFromDB and adding unmatched items from resultsFromAPI
+      const mergedResults = resultsFromDB.map((dbResult) => {
+        const matchingResult = resultsFromApi?.find(
+          (apiResult) => apiResult.instrument_name === dbResult.instrument_name
+        );
+        return matchingResult ? { ...dbResult, ...matchingResult } : dbResult;
+      });
+
+      // Add unmatched items from resultsFromAPI
+      resultsFromApi?.forEach((apiResult) => {
+        const isUnmatched = !resultsFromDB.some(
+          (dbResult) => dbResult.instrument_name === apiResult.instrument_name
+        );
+        if (isUnmatched) {
+          mergedResults.push(apiResult);
+        }
+      });
+
+      setResults(mergedResults);
+    } finally {
+      setLoadingAsset(false);
+    }
   };
 
   const handleManualTransaction = () => {
@@ -67,12 +95,12 @@ function ManualForm({
           className="flex-col lg:flex-row h-24 px-6 items-center gap-4"
         >
           <Shapes height={24} width={24} fill="white" />
-          Manual
+          Others
         </Button>
       </DialogTrigger>
       <DialogContent>
         <div className="md:flex md:gap-2">
-          <DialogTitle>Add Transaction for Manual Assets</DialogTitle>
+          <DialogTitle>Add Transaction for anything</DialogTitle>
         </div>
         <div className="flex w-full flex-col pt-4">
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 md:gap-6 items-center">
@@ -121,4 +149,4 @@ function ManualForm({
   );
 }
 
-export default ManualForm;
+export default OthersForm;

--- a/components/searchResults.tsx
+++ b/components/searchResults.tsx
@@ -79,8 +79,6 @@ const SearchResults = ({
                   <TableCell>
                     <Button
                       onClick={() => {
-                        console.log(result);
-
                         handleAddClick(result);
                       }}
                       className="w-full"

--- a/services/thirdParty/twelveData.ts
+++ b/services/thirdParty/twelveData.ts
@@ -194,7 +194,7 @@ export const searchAssetsFromApi = async ({
   type,
 }: {
   query: string;
-  type: string;
+  type?: string;
 }) => {
   let retryCount = 0;
   const maxRetries = 5; // Maximum number of retries
@@ -216,9 +216,9 @@ export const searchAssetsFromApi = async ({
         throw new Error(`API request failed with status ${res.status}`);
       }
       const { data }: { data: TTwelveDataResult[] } = await res.json();
-      const filteredData = data.filter(
-        (asset) => asset.instrument_type === type
-      );
+      const filteredData = type
+        ? data.filter((asset) => asset.instrument_type === type)
+        : data;
       return filteredData;
     } catch (error) {
       console.error(


### PR DESCRIPTION
This PR renames the `Manual` tab in `+ Add Transaction` button with `Others` and also allows to search for any assets rather than only the manual assets they've already added to their portfolio.