### PR TITLE
fix: realised profit loss and chart dates

### DIFF
--- a/app/(protected)/dashboard/newPage.tsx
+++ b/app/(protected)/dashboard/newPage.tsx
@@ -17,6 +17,7 @@ import {
   TUnrealisedProfitLoss,
   TGroupedAssets,
   THistoricalData,
+  TLineChartData,
 } from "@/types/types";
 import WhitelistingModal from "@/components/onboarding/whitelistingModal";
 import MockLineChart from "@/components/mock/mockLineChart";
@@ -52,13 +53,7 @@ export function Dashboard({
     interval: string;
     data: TGroupedAssets;
   }[];
-  lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
-  }[];
+  lineChartData: TLineChartData;
   unrealisedResults: TUnrealisedProfitLoss[];
   realisedResults: TProfitLoss[];
 }) {

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -11,7 +11,11 @@ import { getConversionRate } from "@/services/thirdParty/currency";
 import { getPreferenceFromUserId } from "@/services/preference";
 import { getUnrealisedProfitLossArray } from "@/helper/unrealisedValueCalculator";
 import { calculateRealisedProfitLoss } from "@/helper/realisedValueCalculator";
-import { TGroupedAssets, TUnrealisedProfitLoss } from "@/types/types";
+import {
+  TGroupedAssets,
+  TLineChartData,
+  TUnrealisedProfitLoss,
+} from "@/types/types";
 import { getDashboardTableData } from "@/services/dashboard/tableData";
 import { getLineChartData } from "@/helper/prepareLineChartData";
 
@@ -41,13 +45,7 @@ const DashboardPage = async () => {
   }
 
   let unrealisedResults: TUnrealisedProfitLoss[] = [];
-  let lineChartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
-  }[] = [];
+  let lineChartData: TLineChartData = [];
   let dashboardTableData: {
     interval: string;
     data: TGroupedAssets;

--- a/components/assetLineChart.tsx
+++ b/components/assetLineChart.tsx
@@ -2,6 +2,7 @@ import {
   formatIndianNumber,
   formatInternationalNumber,
 } from "@/helper/indianNumberingFormatter";
+import { unixTimestampToDate } from "@/lib/helper";
 import React from "react";
 import {
   Area,
@@ -20,6 +21,7 @@ function AssetLineChart({
   dataToShow: {
     name: string;
     amt: number;
+    timestamp: number;
   }[];
   numberSystem: string;
   defaultCurrency: string;
@@ -100,7 +102,9 @@ function AssetLineChart({
                     <span className="font-bold text-muted-foreground flex items-center">
                       {formatter.format(parseFloat(value!))}
                     </span>
-                    <span>{payload[0].payload.name}</span>
+                    <span>
+                      {unixTimestampToDate(payload[0].payload.timestamp)}
+                    </span>
                   </div>
                 </div>
               );

--- a/components/manualTransactionChart.tsx
+++ b/components/manualTransactionChart.tsx
@@ -1,5 +1,10 @@
 "use client";
-import { TAsset, TConversionRates, TInterval } from "@/types/types";
+import {
+  TAsset,
+  TConversionRates,
+  TInterval,
+  TLineChartData,
+} from "@/types/types";
 import {
   formatIndianNumber,
   formatInternationalNumber,
@@ -14,19 +19,14 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { unixTimestampToDate } from "@/lib/helper";
 
 interface ManualTransactionChartProps {
   timeInterval?: TInterval | undefined;
   dashboardAmountVisibility: boolean;
   numberSystem: string;
   defaultCurrency: string;
-  chartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
-  }[];
+  chartData: TLineChartData;
 }
 
 function ManualTransactionChart({
@@ -51,21 +51,6 @@ function ManualTransactionChart({
       amt: number;
     }[]
   >(chartData.filter((data) => data.interval === "All")[0].data);
-
-  // const lineChartData = accumulateLineChartData(historicalData);
-
-  // const seen: Record<string, boolean> = {};
-  // const uniqueData = lineChartData.filter((item) => {
-  //   if (!seen[item.name]) {
-  //     seen[item.name] = true;
-  //     return true;
-  //   }
-  //   return false;
-  // });
-
-  // uniqueData.sort(
-  //   (a, b) => new Date(b.name).getTime() - new Date(a.name).getTime()
-  // );
 
   useEffect(() => {
     timeInterval &&
@@ -156,7 +141,9 @@ function ManualTransactionChart({
                               ? formatter.format(parseFloat(value!))
                               : "* ".repeat(5)}
                           </span>
-                          <span>{payload[0].payload.name}</span>
+                          <span>
+                            {unixTimestampToDate(payload[0].payload.timestamp)}
+                          </span>
                         </div>
                       </div>
                     );

--- a/components/portfolioLineChart.tsx
+++ b/components/portfolioLineChart.tsx
@@ -13,7 +13,8 @@ import {
   formatIndianNumber,
   formatInternationalNumber,
 } from "@/helper/indianNumberingFormatter";
-import { TInterval } from "@/types/types";
+import { TInterval, TLineChartData } from "@/types/types";
+import { unixTimestampToDate } from "@/lib/helper";
 
 function PortfolioLineChart({
   timeInterval,
@@ -23,13 +24,7 @@ function PortfolioLineChart({
   defaultCurrency,
 }: {
   timeInterval?: TInterval;
-  chartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
-  }[];
+  chartData: TLineChartData;
   dashboardAmountVisibility: boolean;
   numberSystem: string;
   defaultCurrency: string;
@@ -135,7 +130,9 @@ function PortfolioLineChart({
                               ? formatter.format(parseFloat(value!))
                               : "* ".repeat(5)}
                           </span>
-                          <span>{payload[0].payload.name}</span>
+                          <span>
+                            {unixTimestampToDate(payload[0].payload.timestamp)}
+                          </span>
                         </div>
                       </div>
                     );

--- a/components/viewAsset.tsx
+++ b/components/viewAsset.tsx
@@ -8,6 +8,7 @@ import TransactionHistory from "./transactionHistory";
 import {
   TAsset,
   TInterval,
+  TLineChartData,
   TProfitLoss,
   TUnrealisedProfitLoss,
 } from "@/types/types";
@@ -26,13 +27,7 @@ interface ViewAssetProps {
   };
   numberSystem: string;
   defaultCurrency: string;
-  chartData: {
-    interval: string;
-    data: {
-      name: string;
-      amt: number;
-    }[];
-  }[];
+  chartData: TLineChartData;
 }
 
 function ViewAsset({
@@ -51,6 +46,7 @@ function ViewAsset({
     {
       name: string;
       amt: number;
+      timestamp: number;
     }[]
   >(chartData.filter((data) => data.interval === "All")[0].data);
   const [currentValue, setCurrentValue] = useState(

--- a/helper/lineChartDataAccumulator.ts
+++ b/helper/lineChartDataAccumulator.ts
@@ -134,6 +134,7 @@ export function accumulateLineChartData(historicalData: THistoricalData[]) {
   const result = Object.keys(finalAggregatedAmounts).map((date) => ({
     name: date,
     amt: finalAggregatedAmounts[date],
+    timestamp: new Date(date).getTime(),
   }));
 
   return result;

--- a/helper/prepareLineChartData.ts
+++ b/helper/prepareLineChartData.ts
@@ -85,6 +85,7 @@ export const getLineChartData = async (
     data: {
       name: string;
       amt: number;
+      timestamp: number;
     }[];
   }[]
 > => {

--- a/helper/realisedValueCalculator.ts
+++ b/helper/realisedValueCalculator.ts
@@ -29,7 +29,11 @@ export function calculateRealisedProfitLoss(
   intervals.forEach(({ label, days }) => {
     const currentDate = new Date();
     const pastDate = new Date(currentDate);
-    pastDate.setDate(currentDate.getDate() - (isFinite(days) ? days : 0));
+    if (days !== Infinity) {
+      pastDate.setDate(currentDate.getDate() - days);
+    } else {
+      pastDate.setTime(0);
+    }
 
     let realisedProfitLoss = 0;
 

--- a/helper/sia/findExisitingCategory.tsx
+++ b/helper/sia/findExisitingCategory.tsx
@@ -49,7 +49,6 @@ export default async function findExistingCategoryFromSia(
 
       // Parsing decrypted data
       const decryptedObject = JSON.parse(decryptedData);
-      console.log(decryptedObject);
       if (decryptedObject.name === categoryName) {
         categoryId = decryptedObject.id;
       }

--- a/helper/transactionValueCalculator.ts
+++ b/helper/transactionValueCalculator.ts
@@ -39,11 +39,19 @@ export function calculateTotalQuantity(transactions: Transaction[]) {
   transactions.sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
-  const totalQuantity = transactions.reduce((total, transaction) => {
+
+  let seenBuyTypeTransaction = false;
+
+  const totalQuantity = transactions.reduce((total, transaction, index) => {
     if (transaction.type === "buy") {
+      seenBuyTypeTransaction = true;
       return total + parseFloat(transaction.quantity);
     } else if (transaction.type === "sell") {
-      return total - parseFloat(transaction.quantity);
+      if (!seenBuyTypeTransaction) {
+        return 0;
+      } else {
+        return total - parseFloat(transaction.quantity);
+      }
     }
     return total;
   }, 0);

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -71,3 +71,14 @@ export function transformToResultFormat(
 export const formatToLocaleString = (value: string | number) => {
   return Number(value).toLocaleString("en-IN");
 };
+
+export const unixTimestampToDate = (unixTimestamp: number): string => {
+  let dateObject = new Date(unixTimestamp);
+  // Extract day, month, and year from the Date object
+  let day = dateObject.getDate();
+  let month = dateObject.getMonth() + 1; // Month is zero-based, so we add 1
+  let year = dateObject.getFullYear();
+  // Format the date as desired
+  let formattedDate = `${day}-${month < 10 ? "0" : ""}${month}-${year}`;
+  return formattedDate;
+};

--- a/types/types.ts
+++ b/types/types.ts
@@ -127,6 +127,7 @@ export type TLineChartData = {
   data: {
     name: string;
     amt: number;
+    timestamp: number;
   }[];
 }[];
 


### PR DESCRIPTION
This PR fixes a calculation bug related to realised profit/loss where it wouldn't show up for `All` time interval and also adds the complete date in linechart's tooltip at all places.